### PR TITLE
add Plugboard, ability to set plugboard settings

### DIFF
--- a/src/plugboard/plugboard.spec.ts
+++ b/src/plugboard/plugboard.spec.ts
@@ -1,0 +1,34 @@
+import { Plugboard } from "./plugboard"
+
+describe("Plugboard tests", () => {
+
+    it("When no connections are set, the plugboard will return the input letter", () => {
+        const plugboard = new Plugboard()
+
+        expect(plugboard.input("A")).toEqual("A")
+        expect(plugboard.input("N")).toEqual("N")
+        expect(plugboard.input("D")).toEqual("D")
+    })
+
+    it("When A is connected to B, input of A is modified to B", () => {
+        const plugboard = new Plugboard()
+
+        const plugboardConnections = new Map()
+        plugboardConnections.set("A", "B")
+
+        plugboard.setConnections(plugboardConnections)
+
+        expect(plugboard.input("A")).toEqual("B")
+    })
+
+    it("When A is connected to B, input of B is modified to A", () => {
+        const plugboard = new Plugboard()
+
+        const plugboardConnections = new Map()
+        plugboardConnections.set("A", "B")
+
+        plugboard.setConnections(plugboardConnections)
+
+        expect(plugboard.input("B")).toEqual("A") 
+    })
+})

--- a/src/plugboard/plugboard.ts
+++ b/src/plugboard/plugboard.ts
@@ -1,0 +1,32 @@
+export class Plugboard {
+    wiring: Map<String, String>;
+
+    constructor() {
+        this.wiring = this.setDefaultConnections()
+    }
+
+    setDefaultConnections() {
+        let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        let wiring = new Map()
+        alphabet.split("").map((letter) => {
+            wiring.set(letter, letter)
+        })
+        return wiring
+    }
+
+    setConnections(plugboardConnections: Map<string, string>) {
+        plugboardConnections.forEach((key, value) => {
+            console.log("Hello")
+            this.makeConnection(key, value)
+        })
+    }
+
+    makeConnection(inputLetter: string, outputLetter: string) {
+        this.wiring.set(inputLetter, outputLetter)
+        this.wiring.set(outputLetter, inputLetter)
+    }
+
+    input(inputLetter: string) {
+        return this.wiring.get(inputLetter)
+    }
+}


### PR DESCRIPTION
This PR adds the Plugboard feature, which allows two letters to be exchanged for one another - if A is set to B, and input of A will return B (before going into the Rotor Mechanism), and B will return A when returning from the Rotor Mechanism.

There is no hard limit of 10 connections which existed in the Enigma (this is something that will be set in the presets).